### PR TITLE
Makes custom file path more robust

### DIFF
--- a/Log.swift
+++ b/Log.swift
@@ -24,10 +24,7 @@ open class Log {
         didSet {
             #if os(macOS)
                 if directory.hasPrefix("~") {
-                    let homeDir = URL(fileURLWithPath: NSHomeDirectory()).path
-                    let index = directory.index(after: directory.startIndex)
-                    let filePath = directory[index...]
-                    directory = "\(homeDir)\(filePath)"
+                    directory = NSString(string: directory).expandingTildeInPath
                 }
             #endif
             

--- a/Log.swift
+++ b/Log.swift
@@ -22,11 +22,7 @@ open class Log {
     ///The directory in which the log files will be written
     open var directory = Log.defaultDirectory() {
         didSet {
-            #if os(macOS)
-                if directory.hasPrefix("~") {
-                    directory = NSString(string: directory).expandingTildeInPath
-                }
-            #endif
+            directory = NSString(string: directory).expandingTildeInPath
             
             let fileManager = FileManager.default
             if !fileManager.fileExists(atPath: directory) {


### PR DESCRIPTION
Uses NSString.expandingTildeInFilePath instead of doing it my own janky way. This would support using ~root/ to reference /var/root/ if you wanted to do that for some reason. It also supports iOS now too, since I didn't realize before that ~/ represents the current application's folder on iOS.

(Also if you could update the Cocoapod that would be great.)